### PR TITLE
fix(SinglePokemon.tsx): Added missing keys to .map()'s

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,7 +7,6 @@ const HomePage: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState<string>('');
 
   useEffect(() => {
-    console.log('is this rendering');
     const foundPoke = pokemonData.filter(pk => {
       return pk.name.toLowerCase().includes(searchTerm.toLowerCase());
     });
@@ -18,7 +17,6 @@ const HomePage: React.FC = () => {
   // useEffect(()=>{},[])
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    console.log(event.target.value);
     setSearchTerm(event.target.value);
   };
 

--- a/src/pages/SinglePokemon.tsx
+++ b/src/pages/SinglePokemon.tsx
@@ -11,7 +11,6 @@ const SinglePokemonPage: React.FC = () => {
     let foundPokemon = pokemonData.find(
       pd => pd.name.toLowerCase() === pokemonName
     );
-    console.log(foundPokemon);
     setPokemon(updateEvolution(foundPokemon));
   }, [pokemonName]);
 
@@ -45,7 +44,6 @@ const SinglePokemonPage: React.FC = () => {
       });
     }
 
-    console.log(poke);
     return poke;
   };
   return (

--- a/src/pages/SinglePokemon.tsx
+++ b/src/pages/SinglePokemon.tsx
@@ -110,7 +110,7 @@ const SinglePokemonPage: React.FC = () => {
                     <div className='row'>
                       {pokemon.prev_evolution?.map((pe, i) => {
                         return (
-                          <div className='col'>
+                          <div className='col' key={i}>
                             <h5 className='text-secondary'>
                               Previous Evolution
                             </h5>
@@ -125,7 +125,7 @@ const SinglePokemonPage: React.FC = () => {
                       })}
                       {pokemon.next_evolution?.map((ne, i) => {
                         return (
-                          <div className='col'>
+                          <div className='col' key={i}>
                             <h5 className='text-secondary'>Next Evolution</h5>
                             <div>
                               <Link to={`/pokemon/${ne.name.toLowerCase()}`}>


### PR DESCRIPTION
## Changes
1. ./src/pages/SinglePokemon.tsx

## Purpose
console error renders when navigating to single Pokemon page

## Approach
Keys are required in React to help identify changes to a list.  `key ={i}`  has been added to the parent div within each `.map()` where there is no `key`

## Learning
Because there is no explicit list item in the file, I referred to React Documentation to confirm `.map()` requires a Key for each iteration

[React Documentation](https://reactjs.org/docs/lists-and-keys.html) 

#4